### PR TITLE
Add proper MIME headers for email

### DIFF
--- a/email.go
+++ b/email.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
-	"github.com/amborle/featmap/tmpl"
 	"html/template"
 	"log"
 	"net/smtp"
+	"time"
+
+	"github.com/amborle/featmap/tmpl"
 )
 
 type welcome struct {
@@ -54,10 +56,10 @@ func ChangeEmailBody(w emailBody) (string, error) {
 }
 
 func (s *service) SendEmail(smtpServer string, smtpPort string, smtpUser string, smtpPass string, from string, recipient string, subject string, body string) error {
+	date := time.Now().Format(time.RFC1123)
 	err := smtp.SendMail(smtpServer+":"+smtpPort,
 		smtp.PlainAuth("", smtpUser, smtpPass, smtpServer),
-		from, []string{recipient}, []byte("Subject:"+subject+"\r\n"+body))
-
+		from, []string{recipient}, []byte("From: "+from+"\r\nTo: "+recipient+"\r\nSubject: "+subject+"\r\nDate: "+date+"\r\n\r\n"+body))
 	if err != nil {
 		log.Printf("smtp error: %s", err)
 		return err


### PR DESCRIPTION
Some SMTP servers reject badly formatted emails. This change fixes that, so the email is not rejected anymore.