### PR TITLE
Pin versions of alpine and node-modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# docker volume for postgres
+data/
+
+# webapp local development artifacts
+webapp/node_modules/
+webapp/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:alpine
+FROM golang:1.15-alpine
 WORKDIR /src
 RUN apk add --update npm git
 RUN go get -u github.com/jteeuwen/go-bindata/...
-COPY ./webapp/package.json webapp/package.json
+COPY ./webapp/package.json ./webapp/package-lock.json webapp/
 RUN cd ./webapp && \
     npm install
 COPY . .


### PR DESCRIPTION
More recent versions of `golang:alpine` fail to compile due to `go get` being deprecated in favour of `go install`, so this pins the golang container to 1.15, when `go get` was still supported. Also, it copies over the package-lock.json file from the webapp folder as part of the docker build so that the npm modules also get their versions pinned to ones that still work; otherwise there were some dependency tree issues while trying to install node modules that would cause the docker build to fail.

I tried going up to `golang:1.16-alpine`, but `npm build` in 1.16 was arguing with me and I didn't have time to explore it further, so left the image pinned to `golang:1.15-alpine`, which seems to work out of the box.