### PR TITLE
Show description on card

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM golang:alpine
+FROM golang:1.15-alpine
 WORKDIR /src
 RUN apk add --update npm git
 RUN go get -u github.com/jteeuwen/go-bindata/...
 COPY ./webapp/package.json webapp/package.json
+COPY ./webapp/package-lock.json webapp/package-lock.json
 RUN cd ./webapp && \
-    npm install
+    npm ci
 COPY . .
 RUN cd ./webapp && \
     npm run build

--- a/webapp/src/components/Board.tsx
+++ b/webapp/src/components/Board.tsx
@@ -699,7 +699,7 @@ class Board extends Component<Props, State> {
                                                                               providedDraggable.draggableProps.style
                                                                             )}>
 
-                                                                            <Card estimate={f.estimate} annotations={f.annotations} nbrOfComments={filterFeatureCommentsOnFeature(this.props.comments, f.id).length} color={f.color} status={f.status} title={f.title} link={this.props.url + "/f/" + f.id} bottomLink={index === ff.length - 1 && !viewOnly ? () => this.setState({ showCreateFeatureModal: true, createFeatureModalMilestoneId: m.id, createFeatureModalSubWorkflowId: sw.id }) : undefined} />
+                                                                            <Card estimate={f.estimate} annotations={f.annotations} nbrOfComments={filterFeatureCommentsOnFeature(this.props.comments, f.id).length} color={f.color} status={f.status} title={f.title} hasDescription={f.description.length > 0} link={this.props.url + "/f/" + f.id} bottomLink={index === ff.length - 1 && !viewOnly ? () => this.setState({ showCreateFeatureModal: true, createFeatureModalMilestoneId: m.id, createFeatureModalSubWorkflowId: sw.id }) : undefined} />
                                                                           </div>
                                                                         </div>
                                                                       )}

--- a/webapp/src/components/Card.tsx
+++ b/webapp/src/components/Card.tsx
@@ -13,6 +13,7 @@ type Props = {
   nbrOfComments?: number
   annotations: string
   estimate?: number
+  hasDescription?: boolean
 };
 
 type State = {};
@@ -46,6 +47,14 @@ class Card extends Component<Props, State> {
                 </div>
                 :
                 null
+              }
+
+              {this.props.hasDescription ?
+                  <div>
+                    <i style={{ fontSize: "12px" }} title="description" className="material-icons align-middle">notes</i>
+                  </div>
+                  :
+                  null
               }
 
               {this.props.nbrOfComments! > 0 ?


### PR DESCRIPTION
I found it difficult to remember which stories have a description, so I added an icon to highlight the cards with description versus those that do not yet have a description.

Change is highlighted below:
![image](https://user-images.githubusercontent.com/1693819/225198054-466858af-6835-4616-a7d1-eb193c501700.png)

Unhighlighted:
![image](https://user-images.githubusercontent.com/1693819/225198215-2ccc4c0b-4d0e-457e-a708-75e1adea4d5d.png)

This PR also has an updated Dockerfile, which was needed for me to get the build working.